### PR TITLE
Fix apollo-client import error: 'import' and 'export' may only appear at the top level

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "semantic-release": "^6.3.2"
   },
   "dependencies": {
-    "apollo-client": "^0.8.2"
+    "apollo-client": "^0.8.2",
+    "graphql-tag": "^1.3.2"
   }
 }

--- a/src/UploadNetworkInterface.js
+++ b/src/UploadNetworkInterface.js
@@ -1,5 +1,5 @@
-import { printAST } from 'apollo-client'
-import { HTTPFetchNetworkInterface, printRequest } from 'apollo-client/transport/networkInterface'
+import { printAST, HTTPFetchNetworkInterface } from 'apollo-client'
+import { print } from 'graphql-tag/bundledPrinter';
 
 export default function createNetworkInterface(opts) {
   const { uri } = opts
@@ -66,3 +66,10 @@ export class UploadNetworkInterface extends HTTPFetchNetworkInterface {
   }
 
 }
+
+function printRequest(request) {
+  return {
+    ...request,
+    query: print(request.query),
+  };
+};


### PR DESCRIPTION
When importing from `'apollo-client/transport/networkInterface'`, the transpiler gives the error:

```
Error: Parsing file node_modules/apollo-client/transport/networkInterface.js: 'import' and 'export' may only appear at the top level (10:0)
```

Which is fixed when importing directly from `'apollo-client'`. Unfortunately, `printRequest` isn't exposed that way, so I copied the function from [here](https://github.com/apollographql/apollo-client/blob/master/src/transport/networkInterface.ts#L83-L88). Therefore, I had to add `graphql-tag` as a direct dependency.

With this low risk fix, everything works fine again.