### PR TITLE
Refactor UploadNetworkInterface

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "semantic-release": "^6.3.2"
   },
   "dependencies": {
-    "apollo-client": "^0.8.2"
+    "apollo-client": "^0.8.2",
+    "object-path": "^0.11.4",
+    "recursive-iterator": "^2.0.3",
+    "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
- Deeply search for File instances in request variables (to fix #5).
- Fall back to original `fetchFromRemoteEndpoint` to stay compatible with changes from [apollo-client](https://github.com/apollographql/apollo-client).
