### PR TITLE
Remove `src` from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .DS_Store
 *.log
-src
 test
 examples
 coverage


### PR DESCRIPTION
This module has:
```
  "module": "src/index.js",
  "jsnext:main": "src/index.js",
```
in the package json, but does not include `src` in the module.